### PR TITLE
Chore: Refactor sendReward and recordParicipation api endpoints

### DIFF
--- a/src/pages/api/recordParticipation.ts
+++ b/src/pages/api/recordParticipation.ts
@@ -81,26 +81,26 @@ function groupedParticipationsByUser(participations: any) : PoolParticipationMap
 return result
 }
 
-function groupedParticipationsByCollectives(participations: any) {
-    const result = Object.values(participations).reduce((acc: PoolParticipationMap, participation: any) => {
-    const key: string = `${participation.cAddress}-${participation.cWallet}-${participation.poolAddress}`
-    if (!acc[key]) {
-        acc[key]  = [
-            {
-                user: participation.user,
-                questionId: participation.questionId,
-                engagement: participation.engagement
-            }
-        ]
-    } else {
-        acc[key].push(
-            {
-                user: participation.user,
-                questionId: participation.questionId,
-                engagement: participation.engagement
-            })
-    }
-    return acc
-    }, {})
-    return result
-}
+// function groupedParticipationsByCollectives(participations: any) {
+//     const result = Object.values(participations).reduce((acc: PoolParticipationMap, participation: any) => {
+//     const key: string = `${participation.cAddress}-${participation.cWallet}-${participation.poolAddress}`
+//     if (!acc[key]) {
+//         acc[key]  = [
+//             {
+//                 user: participation.user,
+//                 questionId: participation.questionId,
+//                 engagement: participation.engagement
+//             }
+//         ]
+//     } else {
+//         acc[key].push(
+//             {
+//                 user: participation.user,
+//                 questionId: participation.questionId,
+//                 engagement: participation.engagement
+//             })
+//     }
+//     return acc
+//     }, {})
+//     return result
+// }

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,12 +75,24 @@ export type CMetadata = {
   salt: number
 }
 
+// export type PoolParticipation = {
+//   user: string
+//   questionId: number
+//   engagement: number
+// }
+// export interface PoolParticipationMap {
+//   [key: string]: PoolParticipation[]
+// }
+
 export type PoolParticipation = {
+  cAddress: string
+  cWallet: string
+  poolAddress: string
   user: string
   questionId: number
   engagement: number
 }
 
 export interface PoolParticipationMap {
-  [key: string]: PoolParticipation[]
+  [key: string]: PoolParticipation
 }

--- a/src/utils/database-operations.ts
+++ b/src/utils/database-operations.ts
@@ -286,11 +286,19 @@ export async function getParticipantsByChannel(channelId: string) {
   try {
     const participants = await sql`
     SELECT 
-      users.wallet_address AS address
+      channels.c_address As cAddress, 
+      channels.c_wallet As cWallet, 
+      channels.c_pool As poolAddress, 
+      user_question_responses.question_id as questionId, 
+      users.wallet_address AS address,
+      users.id AS userId,
+      channels.id AS channelId
     FROM 
       user_question_responses
     LEFT JOIN 
       users ON user_question_responses.user_id = users.id
+    LEFT JOIN 
+      channels ON user_question_responses.channel_id = channels.id
     WHERE 
       user_question_responses.channel_id = ${channelId};
     `
@@ -298,4 +306,19 @@ export async function getParticipantsByChannel(channelId: string) {
   } catch (error) {
     throw error
   }
+}
+
+export async function getWinningChannel() {
+
+  // get winner from last clash inserted into the clashes table
+  const winner = await sql`
+  SELECT clashes.channel_winner_id as id, channels.name as name
+  FROM clashes
+  LEFT JOIN 
+    channels ON clashes.channel_winner_id = channels.id
+  ORDER BY id DESC
+  LIMIT 1;
+  `
+  return winner.rows[0]
+
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
     "crons": [
     {
-      "path": "/api/recordParticipation",
-      "schedule": "0 10 * * *"
+      "path": "/api/sendRewards",
+      "schedule": "0 10 2 3 6"
     },
     {
       "path": "/jobs/update-clashes",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
     "crons": [
     {
       "path": "/api/sendRewards",
-      "schedule": "0 10 2 3 6"
+      "schedule": "0 10 2 3 *"
     },
     {
       "path": "/jobs/update-clashes",


### PR DESCRIPTION
Changes:

Update sendRewards to use new winning channel calculation, and to be called by cron job.

Update recordParticipation api endpoint to only record participation on-chain for the winning channel at the end of challenge